### PR TITLE
A diff patch can be used to add elements to property which is a collection of objects

### DIFF
--- a/SimpleHelpers/ObjectDiffPatch.cs
+++ b/SimpleHelpers/ObjectDiffPatch.cs
@@ -245,7 +245,7 @@ namespace SimpleHelpers
         {
             JToken token;
             // deal with null values
-            if (sourceJson == null || diffJson == null)
+            if (sourceJson == null || diffJson == null || !sourceJson.HasValues)
             {
                 return diffJson;
             }

--- a/Tests/ObjectDiffPatchTest.cs
+++ b/Tests/ObjectDiffPatchTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using SimpleHelpers;
+using System.Linq;
 
 namespace Tests
 {
@@ -140,7 +141,35 @@ namespace Tests
 			Assert.AreEqual(testObj.ListOfObjectProperty[2].StringProperty, revertedObj.ListOfObjectProperty[2].StringProperty);
 			Assert.AreEqual(testObj.ListOfObjectProperty[2].DoubleProperty, revertedObj.ListOfObjectProperty[2].DoubleProperty);
 		}
-	}
+
+        [TestMethod]
+        public void AbleToAddObjectListItemThenApplyViaPatch()
+        {
+            var testObj = GetSimpleTestObject();
+            PopulateObjectListOnTestClass(testObj);
+
+            var updatedTestObj = GetSimpleTestObject();
+            PopulateObjectListOnTestClass(updatedTestObj);
+
+            updatedTestObj.ListOfObjectProperty.Add(new TestClass { StringProperty = "added" });
+
+            var diff = ObjectDiffPatch.GenerateDiff(testObj, updatedTestObj);
+
+            var updatePatch = JsonConvert.SerializeObject(diff.NewValues);
+
+            var objToUpdate = GetSimpleTestObject();
+            PopulateObjectListOnTestClass(objToUpdate);
+
+            var updatedObj = ObjectDiffPatch.PatchObject(objToUpdate, updatePatch);
+
+            Assert.AreEqual(updatedTestObj.ListOfObjectProperty.Count, updatedObj.ListOfObjectProperty.Count);
+
+            var addedListItem = updatedObj.ListOfObjectProperty.SingleOrDefault(obj => obj != null && obj.StringProperty == "added");
+
+            Assert.IsNotNull(addedListItem);
+
+        }
+    }
 
 	public class TestClass
 	{


### PR DESCRIPTION
I've noticed that if a class has a property which is for example of type List<SomeObjectType> it is not possible to patch an instance of this class so that a new element is added to that collection. While the collection is extended, the new element always has a value of null. This fix makes it so that Patch will also check if the sourceJToken has data (which is false for a newly created element in this case).