### PR TITLE
ObjectDiffPatch.PatchObject: Create non generic overload option to provide destination type.

### DIFF
--- a/SimpleHelpers/ObjectDiffPatch.cs
+++ b/SimpleHelpers/ObjectDiffPatch.cs
@@ -176,6 +176,21 @@ namespace SimpleHelpers
         }
 
         /// <summary>
+        /// Modifies an object according to a diff, retuning a new object with applied patch.
+        /// </summary>
+        /// <param name="source">The source.</param>
+        /// <param name="diffJson">The diff json.</param>
+        /// <param name="destinationType">The destination type</param>
+        /// <returns>A new object with applied patch</returns>
+        public static object PatchObject(object source, JObject diffJson, Type destinationType)
+        {
+            var sourceJson = source != null ? Newtonsoft.Json.Linq.JObject.FromObject(source, DefaultSerializer()) : null;
+            var resultJson = Patch(sourceJson, diffJson);
+
+            return resultJson != null ? resultJson.ToObject(destinationType) : null;
+        }
+
+        /// <summary>
         /// Create an object snapshots as a Newtonsoft.Json.Linq.JObject.
         /// </summary>
         /// <typeparam name="T">The type of the T.</typeparam>


### PR DESCRIPTION
I needed a non generic way to provide the destination type.

The problem I encounter was when I loaded something from NHibernate like this:

```
object persitenceEntity = session.Get(persitenceType, id);
persitenceEntity = ObjectDiffPatch.PatchObject(persitenceEntity, diff.NewValues);
```

The issue is that now the generic type is object and it will return a JObject instead of the desired target type which would be the real type of the `persitenceEntity`(you can easily reproduce this yourself).

Btw. you could also consider changing the original overload to if you accept the pull request, maybe thats cleaner.

```
public static T PatchObject<T> (T source, JObject diffJson) where T : class
{
    return (T)PatchObject(source, diffJson, typeof(T));
}
```
